### PR TITLE
Fix 'JSONException : No value for' in LicenseDocument

### DIFF
--- a/r2-lcp/r2-lcp.iml
+++ b/r2-lcp/r2-lcp.iml
@@ -98,13 +98,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/devTestappWithLcp/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/devTestappWithLcp/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/devTestappWithLcp/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDevTestappWithLcp/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDevTestappWithLcp/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDevTestappWithLcp/assets" type="java-test-resource" />
@@ -112,6 +105,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDevTestappWithLcp/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDevTestappWithLcp/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDevTestappWithLcp/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDevTestappWithLcp/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -119,13 +119,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
@@ -133,6 +126,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -140,13 +140,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -154,6 +147,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/attr" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpLicense.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpLicense.kt
@@ -91,12 +91,12 @@ class LcpLicense : DrmLicense {
     override fun areRightsValid() {
         Timber.i(TAG,"LCP areRightsValid")
         val now = Date()
-        license.rights.start.let {
+        license.rights?.start.let {
             if (it != null && it.toDate().after(now)) {
                 throw Exception(LcpError().errorDescription(LcpErrorCase.invalidRights))
             }
         }
-        license.rights.end.let {
+        license.rights?.end.let {
             if (it != null && it.toDate().before(now)) {
                 throw Exception(LcpError().errorDescription(LcpErrorCase.invalidRights))
             }
@@ -313,27 +313,27 @@ class LcpLicense : DrmLicense {
 
     override fun rightsEnd(): Date? {
         Timber.i(TAG,"LCP rightsEnd")
-        return license.rights.end?.toDate()
+        return license.rights?.end?.toDate()
     }
 
     override fun potentialRightsEnd(): Date? {
         Timber.i(TAG,"LCP potentialRightsEnd")
-        return license.rights.potentialEnd?.toDate()
+        return license.rights?.potentialEnd?.toDate()
     }
 
     override fun rightsStart(): Date? {
         Timber.i(TAG,"LCP rightsStart")
-        return license.rights.start?.toDate()
+        return license.rights?.start?.toDate()
     }
 
     override fun rightsPrints(): Int? {
         Timber.i(TAG,"LCP rightsPrints")
-        return license.rights.print
+        return license.rights?.print
     }
 
     override fun rightsCopies(): Int? {
         Timber.i(TAG,"LCP rightsCopies")
-        return license.rights.copy
+        return license.rights?.copy
     }
 
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpSession.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpSession.kt
@@ -98,7 +98,7 @@ class LcpSession {
     }
 
     fun passphraseFromDb() : String? {
-        val passphrases: List<String> = database.transactions.possiblePasshprases(lcpLicense.license.id, lcpLicense.license.user.id)
+        val passphrases: List<String> = database.transactions.possiblePasshprases(lcpLicense.license.id, lcpLicense.license.user?.id)
         if (passphrases.isEmpty())
             return null
         return checkPassphrases(passphrases)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/model/documents/LicenseDocument.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/model/documents/LicenseDocument.kt
@@ -40,9 +40,9 @@ class LicenseDocument {
     /// Used to associate the License Document with resources that are not
     /// locally available.
     var links = listOf<Link>()
-    var rights: Rights
+    var rights: Rights? = null
     /// The user owning the License.
-    var user: User
+    var user: User? = null
     /// Used to validate the license integrity.
     var signature: Signature
     var json: JSONObject
@@ -69,20 +69,32 @@ class LicenseDocument {
         } catch (e: Exception) {
             throw Exception("Lcp parsing error")
         }
+
         encryption = Encryption(JSONObject(json.getString("encryption")))
         links = parseLinks(json["links"] as JSONArray)
-        rights = Rights(json.getJSONObject("rights"))
-        if (json.has("potential_rights")) {
-            rights.potentialEnd = DateTime(json.getJSONObject("potential_rights").getString("end"))
+
+        if (json.has("rights")) {
+            rights = Rights(json.getJSONObject("rights"))
         }
-        user = User(json.getJSONObject("user"))
+
+        if (json.has("potential_rights")) {
+            rights?.potentialEnd = DateTime(json.getJSONObject("potential_rights").getString("end"))
+        }
+
+        if (json.has("user")) {
+            user = User(json.getJSONObject("user"))
+        }
+
         signature = Signature(json.getJSONObject("signature"))
+
         if (json.has("updated")) {
             updated = DateTime(json.getString("updated"))
         }
+
         if (link("hint") == null){
             throw Exception(LcpError().errorDescription(LcpErrorCase.hintLinkNotFound))
         }
+
         if (link("publication") == null){
             throw Exception(LcpError().errorDescription(LcpErrorCase.publicationLinkNotFound))
         }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/model/sub/lcp/User.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/model/sub/lcp/User.kt
@@ -18,9 +18,11 @@ class User(json: JSONObject) {
     private var encrypted = mutableListOf<String>()
 
     init {
-        val encryptedArray = json.getJSONArray("encrypted")
-        for (i in 0 until encryptedArray.length()){
-            encrypted.add(encryptedArray.getString(i))
+        if (json.has("encrypted")) {
+            val encryptedArray = json.getJSONArray("encrypted")
+            for (i in 0 until encryptedArray.length()){
+                encrypted.add(encryptedArray.getString(i))
+            }
         }
     }
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/tables/Licenses.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/tables/Licenses.kt
@@ -129,12 +129,12 @@ class Licenses(var database: LcpDatabaseOpenHelper) {
         if (existingLicense(license.id)) {
             database.use {
                 update(LicensesTable.NAME,
-                        LicensesTable.PRINTSLEFT to license.rights.print,
-                        LicensesTable.COPIESLEFT to license.rights.copy,
+                        LicensesTable.PRINTSLEFT to license.rights?.print,
+                        LicensesTable.COPIESLEFT to license.rights?.copy,
                         LicensesTable.PROVIDER to license.provider.toString(),
                         LicensesTable.ISSUED to license.issued.toString(),
                         LicensesTable.UPDATED to license.updated?.toString(),
-                        LicensesTable.END to license.rights.end?.toString(),
+                        LicensesTable.END to license.rights?.end?.toString(),
                         LicensesTable.STATE to status)
                         .whereArgs("${LicensesTable.ID} = {id}", "id" to license.id)
                         .exec()
@@ -143,12 +143,12 @@ class Licenses(var database: LcpDatabaseOpenHelper) {
             database.use {
                 insert(LicensesTable.NAME,
                         LicensesTable.ID to license.id,
-                        LicensesTable.PRINTSLEFT to license.rights.print,
-                        LicensesTable.COPIESLEFT to license.rights.copy,
+                        LicensesTable.PRINTSLEFT to license.rights?.print,
+                        LicensesTable.COPIESLEFT to license.rights?.copy,
                         LicensesTable.PROVIDER to license.provider.toString(),
                         LicensesTable.ISSUED to license.issued.toString(),
                         LicensesTable.UPDATED to license.issued.toString(),
-                        LicensesTable.END to license.rights.end?.toString(),
+                        LicensesTable.END to license.rights?.end?.toString(),
                         LicensesTable.STATE to status)
             }
         }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/tables/Transactions.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/tables/Transactions.kt
@@ -31,7 +31,7 @@ class Transactions(var database: LcpDatabaseOpenHelper) {
             insert(TransactionsTable.NAME,
                     TransactionsTable.ID to license.license.id ,
                     TransactionsTable.ORIGIN to license.license.provider.toString(),
-                    TransactionsTable.USERID to license.license.user.id,
+                    TransactionsTable.USERID to license.license.user?.id,
                     TransactionsTable.PASSPHRASE to passphraseHash)
         }
 
@@ -43,13 +43,16 @@ class Transactions(var database: LcpDatabaseOpenHelper) {
     ///   - licenseId: <#licenseId description#>
     ///   - provider: <#provider description#>
     /// - Returns: <#return value description#>
-    fun possiblePasshprases(licenseId: String, userId: String): List<String> {
+    fun possiblePasshprases(licenseId: String, userId: String?): List<String> {
 
         val possiblePassphrases = mutableListOf<String>()
         val licensePassphrase: String? = passphrase(licenseId)
-        val userIdPassphrases: List<String> = passphrases(userId)
 
-        possiblePassphrases.addAll(userIdPassphrases)
+        userId?.let {
+            val userIdPassphrases: List<String> = passphrases(userId)
+            possiblePassphrases.addAll(userIdPassphrases)
+        }
+
 
         licensePassphrase?.let { pass ->
             possiblePassphrases.add(pass)


### PR DESCRIPTION
fixes https://github.com/readium/r2-testapp-kotlin/issues/117
Added null safety on objects that may not be specified by the license provider (following the [LCP specification](https://readium.org/technical/readium-lcp-specification/))