### PR TITLE
Removed 'application' element from AndroidManifest.xml.

### DIFF
--- a/r2-lcp/src/main/AndroidManifest.xml
+++ b/r2-lcp/src/main/AndroidManifest.xml
@@ -7,15 +7,4 @@
   ~ LICENSE file present in the project repository where this source code is maintained.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.readium.r2.lcp"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-
-    <application
-        android:allowBackup="false"
-        android:supportsRtl="true"
-        tools:replace="android:allowBackup"/>
-
-</manifest>
+<manifest package="org.readium.r2.lcp" />


### PR DESCRIPTION
The library manifest had defined the attributes 'allowBackup'
and 'supportsRtl'. This may result in a manifest merge error
requiring implementors to use an override like 'tools:replace'.