### PR TITLE
Check hashed passphrase returned by LCPAuthenticating

### DIFF
--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LCPAuthenticating.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LCPAuthenticating.kt
@@ -23,6 +23,7 @@ interface LCPAuthenticating {
      * @param license Information to show to the user about the license being opened.
      * @param reason Reason why the passphrase is requested. It should be used to prompt the user.
      * @param completion Used to return the retrieved passphrase. If the user cancelled, send nil.
+     *        The passphrase may be already hashed.
      */
     fun requestPassphrase(license: LCPAuthenticatedLicense, reason: LCPAuthenticationReason, completion: (String?) -> Unit)
 

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/container/LCPLLicenseContainer.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/container/LCPLLicenseContainer.kt
@@ -23,17 +23,12 @@ internal class LCPLLicenseContainer(private val lcpl: String? = null, private va
 
     var publication: String? = null
 
-    override fun read() : ByteArray {
-        return lcpl?.let {
-            URL(Uri.parse(it).toString()).openStream().readBytes()
-        } ?: run {
-            byteArray?.let {
-                it
-            } ?:run {
-                ByteArray(0)
-            }
+    override fun read() : ByteArray =
+        if (lcpl != null) {
+            URL(Uri.parse(lcpl).toString()).openStream().readBytes()
+        } else {
+            byteArray ?: ByteArray(0)
         }
-    }
 
     override fun write(license: LicenseDocument) {
         publication?.let {

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
@@ -50,7 +50,7 @@ internal class DeviceService(private val repository: DeviceRepository, private v
                 completion(null)
             } else {
                 // TODO templated url
-                val url = link.url(asQueryParameters).toString() ?: throw LCPError.licenseInteractionNotAvailable
+                val url = link.url(asQueryParameters).toString()
 
                 network.fetch(url, method = NetworkService.Method.post, params = asQueryParameters) { status, data ->
                     if (status != 200) {

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
@@ -12,10 +12,10 @@ package org.readium.r2.lcp.service
 import com.mcxiaoke.koi.HASH
 import kotlinx.coroutines.runBlocking
 import org.readium.lcp.sdk.Lcp
+import org.readium.r2.lcp.LCPAuthenticatedLicense
+import org.readium.r2.lcp.LCPAuthenticating
+import org.readium.r2.lcp.LCPAuthenticationReason
 import org.readium.r2.lcp.license.model.LicenseDocument
-import org.readium.r2.lcp.public.LCPAuthenticatedLicense
-import org.readium.r2.lcp.public.LCPAuthenticating
-import org.readium.r2.lcp.public.LCPAuthenticationReason
 
 internal class PassphrasesService(private val repository: PassphrasesRepository) {
 


### PR DESCRIPTION
Same PR for Swift: https://github.com/readium/r2-lcp-swift/pull/75

When the test-app only had a hashed version of a passphrase, it could not send it through `LCPAuthenticating`.

This PR allows to provide both hashed and clear passphrases.

With this, it would be possible to implement retrieving the passphrases using Authentication for OPDS (as defined here: https://readium.org/lcp-specs/notes/lcp-key-retrieval.html) by creating a `OPDSLCPAuthentication` class implementing `LCPAuthenticating`.