### PR TITLE
Prevent crash when requesting the device's Bluetooth name

### DIFF
--- a/r2-lcp/src/main/AndroidManifest.xml
+++ b/r2-lcp/src/main/AndroidManifest.xml
@@ -7,4 +7,10 @@
   ~ LICENSE file present in the project repository where this source code is maintained.
   -->
 
-<manifest package="org.readium.r2.lcp" />
+<manifest package="org.readium.r2.lcp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Used to get the device's name for LSD "register" -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+
+</manifest>

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.runBlocking
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.components.Link
 import org.readium.r2.lcp.LCPError
+import timber.log.Timber
 import java.io.Serializable
 import java.util.*
 
@@ -31,12 +32,13 @@ internal class DeviceService(private val repository: DeviceRepository, private v
         }
     val name: String
         get() {
-            val deviceName = BluetoothAdapter.getDefaultAdapter()
-            return deviceName?.name?.let  {
-                it
-            }?: run {
-               "Android Unknown"
-            }
+            val bluetoothName =
+                try { BluetoothAdapter.getDefaultAdapter()?.name }
+                catch(e: Exception) {
+                    Timber.e(e)
+                    null
+                }
+            return bluetoothName ?: "Android"
         }
 
     val asQueryParameters: MutableList<Pair<String, Any?>>


### PR DESCRIPTION
Fix #66 

I put the BLUETOOTH permission in the lib's manifest, so it shouldn't be required in the app's.