### PR TITLE
Fix download location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
   * All asynchronous APIs are now suspending to take advantage of Kotlin's coroutines.
   * Follow the deprecation warnings to upgrade to the new names.
 * `LcpAuthenticating` is now provided with more information and you will need to update your implementation.
+* Publications are now downloaded to a temporary location, to make sure disk storage can be recovered automatically by the system. After acquiring the publication, you need to move the downloaded file to another permanent location.
 
 ### Fixed
 

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -11,21 +11,21 @@ package org.readium.r2.lcp.service
 
 import android.content.Context
 import kotlinx.coroutines.*
-import org.readium.r2.lcp.*
 import org.readium.r2.lcp.BuildConfig.DEBUG
+import org.readium.r2.lcp.LcpAuthenticating
+import org.readium.r2.lcp.LcpException
+import org.readium.r2.lcp.LcpLicense
+import org.readium.r2.lcp.LcpService
 import org.readium.r2.lcp.license.License
 import org.readium.r2.lcp.license.LicenseValidation
 import org.readium.r2.lcp.license.container.LicenseContainer
 import org.readium.r2.lcp.license.container.createLicenseContainer
 import org.readium.r2.lcp.license.model.LicenseDocument
-import org.readium.r2.lcp.public.*
 import org.readium.r2.shared.extensions.tryOr
 import org.readium.r2.shared.format.Format
-import java.io.File
 import org.readium.r2.shared.util.Try
 import timber.log.Timber
-import java.util.Properties
-import java.util.UUID
+import java.io.File
 import kotlin.coroutines.resume
 
 
@@ -48,9 +48,9 @@ internal class LicensesService(
         try {
             val licenseDocument = LicenseDocument(lcpl)
             if (DEBUG) Timber.d("license ${licenseDocument.json}")
-            fetchPublication(licenseDocument, context).let { Try.success(it) }
+            fetchPublication(licenseDocument).let { Try.success(it) }
         } catch (e: Exception) {
-           Try.failure(LcpException.wrap(e))
+            Try.failure(LcpException.wrap(e))
         }
 
     override suspend fun retrieveLicense(file: File, authentication: LcpAuthenticating?, allowUserInteraction: Boolean, sender: Any?): Try<LcpLicense, LcpException>? =
@@ -123,25 +123,14 @@ internal class LicensesService(
         }
     }
 
-    private suspend fun fetchPublication(license: LicenseDocument, context: Context): LcpService.AcquiredPublication {
+    private suspend fun fetchPublication(license: LicenseDocument): LcpService.AcquiredPublication {
         val link = license.link(LicenseDocument.Rel.publication)
         val url = link?.url
             ?: throw LcpException.Parsing.Url(rel = LicenseDocument.Rel.publication.rawValue)
 
-        val properties =  Properties()
-        withContext(Dispatchers.IO) {
-            context.assets.open("configs/config.properties").let { properties.load(it) }
+        val destination = withContext(Dispatchers.IO) {
+            File.createTempFile("lcp-${System.currentTimeMillis()}", ".tmp")
         }
-        val useExternalFileDir = properties.getProperty("useExternalFileDir", "false")!!.toBoolean()
-
-        val rootDir: String =  if (useExternalFileDir) {
-            context.getExternalFilesDir(null)?.path + "/"
-        } else {
-            context.filesDir.path + "/"
-        }
-
-        val fileName = UUID.randomUUID().toString()
-        val destination = File(rootDir, fileName)
         if (DEBUG) Timber.i("LCP destination $destination")
 
         val format = network.download(url, destination) ?: Format.of(mediaType = link.type) ?: Format.EPUB


### PR DESCRIPTION
It's easy to have an ever-growing list of LCP publications polluting the disk if we don't handle correctly the files returned by `acquire()`. To prevent this, I changed the download location to a temporary path, so that the system can recover this space if the app forgets to delete it.