### PR TITLE
Some changes in LcpService API

### DIFF
--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
@@ -21,7 +21,7 @@ import org.readium.r2.shared.util.Try
 
 internal class LcpContentProtection(
     private val lcpService: LcpService,
-    private val authentication: LcpAuthenticating?
+    private val authentication: LcpAuthenticating
 ) : ContentProtection {
 
     override suspend fun open(

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
@@ -21,7 +21,7 @@ import org.readium.r2.shared.util.Try
 
 internal class LcpContentProtection(
     private val lcpService: LcpService,
-    private val authentication: LcpAuthenticating
+    private val authentication: LcpAuthenticating?
 ) : ContentProtection {
 
     override suspend fun open(

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.persistence.Database
 import org.readium.r2.lcp.service.*
 import org.readium.r2.shared.publication.ContentProtection
@@ -46,6 +47,8 @@ interface LcpService {
             Try.failure(LcpException.wrap(e))
         }
     }
+
+    suspend fun addPassphrase(license: LicenseDocument, passphrase: String)
 
     /**
      * Opens the LCP license of a protected publication, to access its DRM metadata and decipher

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -67,7 +67,7 @@ interface LcpService {
      * Creates a [ContentProtection] instance which can be used with a Streamer to unlock
      * LCP protected publications.
      */
-    fun contentProtection(authentication: LcpAuthenticating? = null): ContentProtection =
+    fun contentProtection(authentication: LcpAuthenticating): ContentProtection =
         LcpContentProtection(this, authentication)
 
     /**

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -64,7 +64,7 @@ interface LcpService {
      * Creates a [ContentProtection] instance which can be used with a Streamer to unlock
      * LCP protected publications.
      */
-    fun contentProtection(authentication: LcpAuthenticating): ContentProtection =
+    fun contentProtection(authentication: LcpAuthenticating? = null): ContentProtection =
         LcpContentProtection(this, authentication)
 
     /**

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -48,7 +48,11 @@ interface LcpService {
         }
     }
 
-    suspend fun addPassphrase(license: LicenseDocument, passphrase: String)
+    suspend fun addPassphrase(passphrase: String, hashed: Boolean, license: LicenseDocument) =
+        addPassphrase(passphrase, hashed, provider = license.provider, userId = license.user.id)
+
+    suspend fun addPassphrase(passphrase: String, hashed: Boolean, licenseId: String? = null, provider: String? = null, userId: String? = null)
+
 
     /**
      * Opens the LCP license of a protected publication, to access its DRM metadata and decipher

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/License.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/License.kt
@@ -22,7 +22,6 @@ import org.readium.r2.lcp.service.DeviceService
 import org.readium.r2.lcp.service.LicensesRepository
 import org.readium.r2.lcp.service.NetworkService
 import org.readium.r2.lcp.service.URLParameters
-import org.readium.r2.shared.format.MediaType
 import org.readium.r2.shared.util.Try
 import timber.log.Timber
 import java.net.HttpURLConnection

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/persistence/Transactions.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/persistence/Transactions.kt
@@ -55,6 +55,17 @@ internal class Transactions(var database: LcpDatabaseOpenHelper) : PassphrasesRe
         }
     }
 
+    override fun allPassphrases(): List<String> =
+        database.use {
+            select(TransactionsTable.NAME, TransactionsTable.PASSPHRASE)
+                .exec {
+                    val parser = rowParser { result: String ->
+                        return@rowParser result
+                    }
+                    parseList(parser)
+                }
+        }
+
     override fun addPassphrase(passphraseHash: String, licenseId: String?, provider: String?, userId: String?) {
         database.use {
             insert(TransactionsTable.NAME,

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/persistence/Transactions.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/persistence/Transactions.kt
@@ -55,7 +55,7 @@ internal class Transactions(var database: LcpDatabaseOpenHelper) : PassphrasesRe
         }
     }
 
-    override fun addPassphrase(passphraseHash: String, licenseId: String, provider: String, userId: String?) {
+    override fun addPassphrase(passphraseHash: String, licenseId: String?, provider: String?, userId: String?) {
         database.use {
             insert(TransactionsTable.NAME,
                     TransactionsTable.ID to licenseId,

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -44,6 +44,9 @@ internal class LicensesService(
             true
         }
 
+    override suspend fun addPassphrase(license: LicenseDocument, passphrase: String) =
+        passphrases.addPassphrase(license, passphrase)
+
     override suspend fun acquirePublication(lcpl: ByteArray): Try<LcpService.AcquiredPublication, LcpException> =
         try {
             val licenseDocument = LicenseDocument(lcpl)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -44,8 +44,8 @@ internal class LicensesService(
             true
         }
 
-    override suspend fun addPassphrase(license: LicenseDocument, passphrase: String) =
-        passphrases.addPassphrase(license, passphrase)
+    override suspend fun addPassphrase(passphrase: String, hashed: Boolean, licenseId: String?, provider: String?, userId: String?)  =
+        passphrases.addPassphrase(passphrase, hashed, licenseId, provider, userId)
 
     override suspend fun acquirePublication(lcpl: ByteArray): Try<LcpService.AcquiredPublication, LcpException> =
         try {

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesRepository.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesRepository.kt
@@ -12,5 +12,5 @@ package org.readium.r2.lcp.service
 internal interface PassphrasesRepository {
     fun passphrase(licenseId: String) : String?
     fun passphrases(userId: String) : List<String>
-    fun addPassphrase(passphraseHash: String, licenseId: String, provider: String, userId: String?)
+    fun addPassphrase(passphraseHash: String, licenseId: String?, provider: String?, userId: String?)
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesRepository.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesRepository.kt
@@ -12,5 +12,6 @@ package org.readium.r2.lcp.service
 internal interface PassphrasesRepository {
     fun passphrase(licenseId: String) : String?
     fun passphrases(userId: String) : List<String>
+    fun allPassphrases(): List<String>
     fun addPassphrase(passphraseHash: String, licenseId: String?, provider: String?, userId: String?)
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
@@ -67,6 +67,7 @@ internal class PassphrasesService(private val repository: PassphrasesRepository)
             val userPassphrases = repository.passphrases(userId)
             passphrases.addAll(userPassphrases)
         }
+        passphrases.addAll(repository.allPassphrases())
         return passphrases
     }
 

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
@@ -44,15 +44,17 @@ internal class PassphrasesService(private val repository: PassphrasesRepository)
 
         return try {
             val passphrase = Lcp().findOneValidPassphrase(license.json.toString(), passphrases.toTypedArray())
-            addPassphrase(license, passphrase)
+            addPassphrase(passphrase, true, license.id, license.provider, license.user.id)
             passphrase
         } catch (e: Exception) {
             authenticate(license, LcpAuthenticating.AuthenticationReason.InvalidPassphrase, authentication, allowUserInteraction, sender)
         }
     }
 
-    fun addPassphrase(license: LicenseDocument, passphrase: String) =
-        this.repository.addPassphrase(passphrase, license.id, license.provider, license.user.id)
+    fun addPassphrase(passphrase: String, hashed:Boolean, licenseId: String?, provider: String?, userId: String?) {
+        val hashedPassphrase = if (hashed) passphrase else HASH.sha256(passphrase)
+        this.repository.addPassphrase(hashedPassphrase, licenseId, provider, userId)
+    }
 
     private fun possiblePassphrasesFromRepository(license: LicenseDocument): List<String> {
         val passphrases: MutableList<String> = mutableListOf()

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
@@ -44,12 +44,15 @@ internal class PassphrasesService(private val repository: PassphrasesRepository)
 
         return try {
             val passphrase = Lcp().findOneValidPassphrase(license.json.toString(), passphrases.toTypedArray())
-            this.repository.addPassphrase(passphrase, license.id, license.provider, license.user.id)
+            addPassphrase(license, passphrase)
             passphrase
         } catch (e: Exception) {
             authenticate(license, LcpAuthenticating.AuthenticationReason.InvalidPassphrase, authentication, allowUserInteraction, sender)
         }
     }
+
+    fun addPassphrase(license: LicenseDocument, passphrase: String) =
+        this.repository.addPassphrase(passphrase, license.id, license.provider, license.user.id)
 
     private fun possiblePassphrasesFromRepository(license: LicenseDocument): List<String> {
         val passphrases: MutableList<String> = mutableListOf()

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/PassphrasesService.kt
@@ -57,7 +57,7 @@ internal class PassphrasesService(private val repository: PassphrasesRepository)
     }
 
     private fun possiblePassphrasesFromRepository(license: LicenseDocument): List<String> {
-        val passphrases: MutableList<String> = mutableListOf()
+        val passphrases: MutableSet<String> = linkedSetOf()
         val licensePassphrase = repository.passphrase(license.id)
         if (licensePassphrase != null) {
             passphrases.add(licensePassphrase)
@@ -68,7 +68,7 @@ internal class PassphrasesService(private val repository: PassphrasesRepository)
             passphrases.addAll(userPassphrases)
         }
         passphrases.addAll(repository.allPassphrases())
-        return passphrases
+        return passphrases.toList()
     }
 
     companion object {


### PR DESCRIPTION
Libraries are likely to use only [Automatic Key Retrieval](https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#automatic-lcp-key-retrieval-use-of-authentication-for-opds) without any UI to input the passphrase.

Therefore, I think `LcpAuthenticating` may be optional in `LcpService.contentProtection` and `LcpService` should expose a simple way to add a passphrase to the repository.