### PR TITLE
Use the link.type as a fallback for the acquisition media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 * Upgraded to Kotlin 1.4.10.
 
+## Fixed
+
+* When acquiring a publication, falls back on the media type declared in the license link if the server returns an unknown media type.
+
 
 ## [2.0.0-alpha.2]
 

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/LicensesService.kt
@@ -133,7 +133,7 @@ internal class LicensesService(
         }
         if (DEBUG) Timber.i("LCP destination $destination")
 
-        val format = network.download(url, destination) ?: Format.of(mediaType = link.type) ?: Format.EPUB
+        val format = network.download(url, destination, mediaType = link.type) ?: Format.of(mediaType = link.type) ?: Format.EPUB
 
         // Saves the License Document into the downloaded publication
         val container = createLicenseContainer(destination.path, format)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/NetworkService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/NetworkService.kt
@@ -71,7 +71,7 @@ internal class NetworkService {
             }
         }
 
-    suspend fun download(url: URL, destination: File): Format? = withContext(Dispatchers.IO) {
+    suspend fun download(url: URL, destination: File, mediaType: String? = null): Format? = withContext(Dispatchers.IO) {
         try {
             val connection = url.openConnection() as HttpURLConnection
             if (connection.responseCode != HttpURLConnection.HTTP_OK) {
@@ -88,7 +88,7 @@ internal class NetworkService {
                 }
             }
 
-            connection.sniffFormat()
+            connection.sniffFormat(mediaTypes = listOfNotNull(mediaType))
 
         } catch (e: Exception) {
             Timber.e(e)


### PR DESCRIPTION
If the server doesn't return any valid media type for an acquisition link, we will fall back on the type declared in the license.