### PR TITLE
Various networking fixes

### DIFF
--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/LicenseDocument.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/LicenseDocument.kt
@@ -19,6 +19,7 @@ import org.readium.r2.lcp.license.model.components.lcp.Rights
 import org.readium.r2.lcp.license.model.components.lcp.Signature
 import org.readium.r2.lcp.license.model.components.lcp.User
 import org.readium.r2.lcp.service.URLParameters
+import org.readium.r2.shared.util.mediatype.MediaType
 import java.net.URL
 import java.nio.charset.Charset
 
@@ -66,14 +67,18 @@ class LicenseDocument(val data: ByteArray) {
         }
     }
 
-    fun link(rel: Rel): Link? =
-            links[rel.rawValue].firstOrNull()
+    fun link(rel: Rel, type: MediaType? = null): Link? =
+        links.firstWithRel(rel.rawValue, type)
 
-    fun links(rel: Rel): List<Link> =
-            links[rel.rawValue]
+    fun links(rel: Rel, type: MediaType? = null): List<Link> =
+        links.allWithRel(rel.rawValue, type)
 
-    fun url(rel: Rel, parameters:  URLParameters = emptyMap()): URL {
-        return link(rel)?.url(parameters) ?: throw LcpException.Parsing.Url(rel = rel.rawValue)
+    fun url(rel: Rel, preferredType: MediaType? = null, parameters:  URLParameters = emptyMap()): URL {
+        val link = link(rel, preferredType)
+            ?: links.firstWithRelAndNoType(rel.rawValue)
+            ?: throw LcpException.Parsing.Url(rel = rel.rawValue)
+
+        return link.url(parameters)
     }
 
     val description: String

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/StatusDocument.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/StatusDocument.kt
@@ -17,6 +17,7 @@ import org.readium.r2.lcp.license.model.components.Links
 import org.readium.r2.lcp.license.model.components.lsd.Event
 import org.readium.r2.lcp.license.model.components.lsd.PotentialRights
 import org.readium.r2.lcp.service.URLParameters
+import org.readium.r2.shared.util.mediatype.MediaType
 import java.net.URL
 import java.nio.charset.Charset
 
@@ -87,14 +88,18 @@ class StatusDocument(val data: ByteArray) {
 
     }
 
-    fun link(rel: Rel): Link? =
-            links[rel.rawValue].firstOrNull()
+    fun link(rel: Rel, type: MediaType? = null): Link? =
+        links.firstWithRel(rel.rawValue, type)
 
-    fun links(rel: Rel): List<Link> =
-            links[rel.rawValue]
+    fun links(rel: Rel, type: MediaType? = null): List<Link> =
+        links.allWithRel(rel.rawValue, type)
 
-    fun url(rel: Rel, parameters:  URLParameters = emptyMap()): URL {
-        return link(rel)?.url(parameters) ?: throw LcpException.Parsing.Url(rel = rel.rawValue)
+    fun url(rel: Rel, preferredType: MediaType? = null, parameters:  URLParameters = emptyMap()): URL {
+        val link = link(rel, preferredType)
+            ?: links.firstWithRelAndNoType(rel.rawValue)
+            ?: throw LcpException.Parsing.Url(rel = rel.rawValue)
+
+        return link.url(parameters)
     }
 
     fun events(type: Event.EventType): List<Event> =

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/Link.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/Link.kt
@@ -56,7 +56,7 @@ data class Link(val json: JSONObject) {
 
     }
 
-    fun url(parameters:  URLParameters) : URL? {
+    fun url(parameters:  URLParameters) : URL {
         if (!templated) {
             return URL(href)
         }
@@ -65,7 +65,7 @@ data class Link(val json: JSONObject) {
         return URL(expandedHref)
     }
 
-    val url: URL?
+    val url: URL
         get() = url(parameters = emptyMap())
 
     val mediaType: MediaType

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/CRLService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/CRLService.kt
@@ -18,6 +18,7 @@ import org.joda.time.Days
 import org.readium.r2.lcp.BuildConfig.DEBUG
 import org.readium.r2.lcp.LcpException
 import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.getOrElse
 import timber.log.Timber
 import java.util.*
 
@@ -49,11 +50,8 @@ internal class CRLService(val network: NetworkService, val context: Context) {
 
     private suspend fun fetch(): String {
         val url = "http://crl.edrlab.telesec.de/rl/EDRLab_CA.crl"
-        val (status, data) = network.fetch(url, NetworkService.Method.GET)
-        if (DEBUG) Timber.d("Status $status")
-        if (status != 200 || data == null) {
-            throw LcpException.CrlFetching
-        }
+        val data = network.fetch(url, NetworkService.Method.GET)
+            .getOrElse { throw LcpException.CrlFetching }
 
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 "-----BEGIN X509 CRL-----${Base64.getEncoder().encodeToString(data)}-----END X509 CRL-----"

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/DeviceService.kt
@@ -12,7 +12,6 @@ package org.readium.r2.lcp.service
 import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import android.content.SharedPreferences
-import kotlinx.coroutines.runBlocking
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.components.Link
 import timber.log.Timber
@@ -50,10 +49,8 @@ internal class DeviceService(private val repository: DeviceRepository, private v
         }
 
         val url = link.url(asQueryParameters).toString()
-        val (status, data) = network.fetch(url, NetworkService.Method.POST, asQueryParameters)
-        if (status != 200 || data == null) {
-            return null
-        }
+        val data = network.fetch(url, NetworkService.Method.POST, asQueryParameters)
+            .getOrNull() ?: return null
 
         repository.registerDevice(license)
         return data


### PR DESCRIPTION
* Fix getting the license or status links if there are several listed with different media types
    * Use case: an LSD listing also an ACSM license in the `links`.
* Fix considering HTTP redirect statuses (< 400) as errors
* Simplify networking code