### PR TITLE
Revamp the Renew Loan API + rights extensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Changed
+
+* The Renew Loan API got revamped to better support renewal through a web page.
+    * You will need to implement `LcpLicense.RenewListener` to coordinate the UX interaction.
+    * If your application fits Material Design guidelines, take a look at `MaterialRenewListener` for a default implementation.
+
 ## [2.0.0-beta.1]
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## Changed
+### Added
+
+* Extensibility in licenses' `Rights` model.
+
+### Changed
 
 * The Renew Loan API got revamped to better support renewal through a web page.
     * You will need to implement `LcpLicense.RenewListener` to coordinate the UX interaction.
     * If your application fits Material Design guidelines, take a look at `MaterialRenewListener` for a default implementation.
+* Removed dependency on Joda's `DateTime` in public APIs.
+    * You can always create a `DateTime` from the standard `Date` objects if you relied on Joda's features in the callers.
 
 ## [2.0.0-beta.1]
 
-## Changed
+### Changed
 
 * Upgraded to Kotlin 1.4.10.
 
-## Fixed
+### Fixed
 
 * When acquiring a publication, falls back on the media type declared in the license link if the server returns an unknown media type.
 

--- a/r2-lcp/build.gradle
+++ b/r2-lcp/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation "joda-time:joda-time:2.10.5"
     implementation "org.jetbrains.anko:anko-sqlite:0.10.8"
     implementation "org.zeroturnaround:zt-zip:1.14"
+    implementation 'androidx.browser:browser:1.3.0'
 
     testImplementation "junit:junit:4.13.1"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpException.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpException.kt
@@ -8,9 +8,9 @@ package org.readium.r2.lcp
 
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
-import org.joda.time.DateTime
 import org.readium.r2.shared.UserException
 import java.net.SocketTimeoutException
+import java.util.*
 
 sealed class LcpException(userMessageId: Int, vararg args: Any, quantity: Int? = null, cause: Throwable? = null) : UserException(userMessageId, args, quantity, cause) {
     constructor(@StringRes userMessageId: Int, vararg args: Any, cause: Throwable? = null) : this(userMessageId, *args, quantity = null, cause = cause)
@@ -49,13 +49,13 @@ sealed class LcpException(userMessageId: Int, vararg args: Any, quantity: Int? =
         constructor(@StringRes userMessageId: Int, vararg args: Any) : this(userMessageId, *args, quantity = null)
         constructor(@PluralsRes userMessageId: Int, quantity: Int, vararg args: Any) : this(userMessageId, *args, quantity = quantity)
 
-        class Cancelled(val date: DateTime) : LicenseStatus(R.string.r2_lcp_exception_license_status_cancelled, date)
+        class Cancelled(val date: Date) : LicenseStatus(R.string.r2_lcp_exception_license_status_cancelled, date)
 
-        class Returned(val date: DateTime) : LicenseStatus(R.string.r2_lcp_exception_license_status_returned, date)
+        class Returned(val date: Date) : LicenseStatus(R.string.r2_lcp_exception_license_status_returned, date)
 
-        class NotStarted(val start: DateTime) : LicenseStatus(R.string.r2_lcp_exception_license_status_not_started, start)
+        class NotStarted(val start: Date) : LicenseStatus(R.string.r2_lcp_exception_license_status_not_started, start)
 
-        class Expired(val end: DateTime) : LicenseStatus(R.string.r2_lcp_exception_license_status_expired, end)
+        class Expired(val end: Date) : LicenseStatus(R.string.r2_lcp_exception_license_status_expired, end)
 
         /**
          * If the license has been revoked, the user message should display the number of devices which
@@ -63,7 +63,7 @@ sealed class LcpException(userMessageId: Int, vararg args: Any, quantity: Int? =
          * in the status document. If no event is logged in the status document, no such message should
          * appear (certainly not "The license was registered by 0 devices").
          */
-        class Revoked(val date: DateTime, val devicesCount: Int)
+        class Revoked(val date: Date, val devicesCount: Int)
             : LicenseStatus(R.plurals.r2_lcp_exception_license_status_revoked, devicesCount, date, devicesCount)
     }
 
@@ -76,7 +76,7 @@ sealed class LcpException(userMessageId: Int, vararg args: Any, quantity: Int? =
         object RenewFailed : Renew(R.string.r2_lcp_exception_renew_renew_failed)
 
         /** Incorrect renewal period, your publication could not be renewed. */
-        class InvalidRenewalPeriod(val maxRenewDate: DateTime?) : Renew(R.string.r2_lcp_exception_renew_invalid_renewal_period)
+        class InvalidRenewalPeriod(val maxRenewDate: Date?) : Renew(R.string.r2_lcp_exception_renew_invalid_renewal_period)
 
         /** An unexpected error has occurred on the licensing server. */
         object UnexpectedServerError : Renew(R.string.r2_lcp_exception_renew_unexpected_server_error)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpLicense.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpLicense.kt
@@ -6,7 +6,9 @@
 
 package org.readium.r2.lcp
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.joda.time.DateTime
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.StatusDocument
@@ -14,7 +16,7 @@ import org.readium.r2.shared.publication.services.ContentProtectionService
 import org.readium.r2.shared.util.Try
 import timber.log.Timber
 import java.net.URL
-import kotlin.coroutines.resume
+import java.util.*
 
 /**
  * Opened license, used to decipher a protected publication and manage its license.
@@ -55,13 +57,12 @@ interface LcpLicense : ContentProtectionService.UserRights {
     val maxRenewDate: DateTime?
 
     /**
-     * Renews the loan up to a certain date (if possible).
+     * Renews the loan by starting a renew LSD interaction.
      *
-     * @param urlPresenter: Used when the renew requires to present an HTML page to the user.
-     *        A reading app should implement it with a `suspendCoroutine` statement to return the
-     *        control once the user dismissed the browser view.
+     * @param prefersWebPage Indicates whether the loan should be renewed through a web page if
+     *        available, instead of programmatically.
      */
-    suspend fun renewLoan(end: DateTime?, urlPresenter: suspend (URL) -> Unit): Try<Unit, LcpException>
+    suspend fun renewLoan(listener: RenewListener, prefersWebPage: Boolean = false): Try<Date?, LcpException>
 
     /**
      * Can the user return the loaned publication?
@@ -79,6 +80,32 @@ interface LcpLicense : ContentProtectionService.UserRights {
     suspend fun decrypt(data: ByteArray): Try<ByteArray, LcpException>
 
 
+    /**
+     * UX delegate for the loan renew LSD interaction.
+     *
+     * If your application fits Material Design guidelines, take a look at [MaterialRenewListener]
+     * for a default implementation.
+     */
+    interface RenewListener {
+
+        /**
+         * Called when the renew interaction allows to customize the end date programmatically.
+         * You can prompt the user for the number of days to renew, for example.
+         *
+         * The returned date can't exceed [maximumDate].
+         */
+        suspend fun preferredEndDate(maximumDate: Date?): Date?
+
+        /**
+         * Called when the renew interaction uses an HTML web page.
+         *
+         * You should present the URL in a Chrome Custom Tab and terminate the function when the
+         * web page is dismissed by the user.
+         */
+        suspend fun openWebPage(url: URL)
+
+    }
+
     @Deprecated("Use `license.encryption.profile` instead", ReplaceWith("license.encryption.profile"))
     val encryptionProfile: String? get() =
         license.encryption.profile
@@ -89,23 +116,11 @@ interface LcpLicense : ContentProtectionService.UserRights {
             .onFailure { Timber.e(it) }
             .getOrNull()
 
-    @Deprecated("Use `renewLoan()` with coroutines instead", ReplaceWith("renewLoan)"))
-    fun renewLoan(end: DateTime?, present: (URL, dismissed: () -> Unit) -> Unit, completion: (LcpException?) -> Unit) {
-        GlobalScope.launch {
-            suspend fun presentUrl(url: URL) {
-                suspendCancellableCoroutine<Unit> { cont ->
-                    present(url) {
-                        if (cont.isActive) {
-                            cont.resume(Unit)
-                        }
-                    }
-                }
-            }
+    @Deprecated("Use `renewLoan` with `RenewListener` instead", ReplaceWith("renewLoan(LcpLicense.RenewListener)"), level = DeprecationLevel.ERROR)
+    suspend fun renewLoan(end: DateTime?, urlPresenter: suspend (URL) -> Unit): Try<Unit, LcpException> = Try.success(Unit)
 
-            val result = renewLoan(end, ::presentUrl)
-            completion(result.exceptionOrNull())
-        }
-    }
+    @Deprecated("Use `renewLoan` with `RenewListener` instead", ReplaceWith("renewLoan(LcpLicense.RenewListener)"), level = DeprecationLevel.ERROR)
+    fun renewLoan(end: DateTime?, present: (URL, dismissed: () -> Unit) -> Unit, completion: (LcpException?) -> Unit) {}
 
     @Deprecated("Use `returnPublication()` with coroutines instead", ReplaceWith("returnPublication"))
     fun returnPublication(completion: (LcpException?) -> Unit) {
@@ -115,7 +130,6 @@ interface LcpLicense : ContentProtectionService.UserRights {
     }
 
 }
-
 
 @Deprecated("Renamed to `LcpService`", replaceWith = ReplaceWith("LcpService"))
 typealias LCPService = LcpService

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpLicense.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpLicense.kt
@@ -54,7 +54,7 @@ interface LcpLicense : ContentProtectionService.UserRights {
      * The maximum potential date to renew to.
      * If null, then the renew date might not be customizable.
      */
-    val maxRenewDate: DateTime?
+    val maxRenewDate: Date?
 
     /**
      * Renews the loan by starting a renew LSD interaction.

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/MaterialRenewListener.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/MaterialRenewListener.kt
@@ -38,7 +38,7 @@ class MaterialRenewListener(
 ) : LcpLicense.RenewListener {
 
     override suspend fun preferredEndDate(maximumDate: Date?): Date? = suspendCancellableCoroutine { cont ->
-        val start = license.license.rights.end?.millis ?: Date().time
+        val start = (license.license.rights.end ?: Date()).time
         val end = maximumDate?.time
 
         MaterialDatePicker.Builder.datePicker()

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/MaterialRenewListener.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/MaterialRenewListener.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Readium Foundation. All rights reserved.
+ * Use of this source code is governed by the BSD-style license
+ * available in the top-level LICENSE file of the project.
+ */
+
+package org.readium.r2.lcp
+
+import android.net.Uri
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.fragment.app.FragmentManager
+import com.google.android.material.datepicker.*
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.net.URL
+import java.util.*
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A default implementation of the [LcpLicense.RenewListener] using Chrome Custom Tabs for
+ * presenting web pages and a Material Date Picker for choosing the renew date.
+ *
+ * [MaterialRenewListener] must be initialized before its parent component is in a RESUMED state,
+ * because it needs to register an ActivityResultLauncher. Basically, create it in your
+ * Activity/Fragment's onCreate.
+ *
+ * @param license LCP license which will be renewed.
+ * @param caller Activity or Fragment used to register the ActivityResultLauncher.
+ * @param fragmentManager FragmentManager used to present the date picker.
+ */
+class MaterialRenewListener(
+    private val license: LcpLicense,
+    private val caller: ActivityResultCaller,
+    private val fragmentManager: FragmentManager
+) : LcpLicense.RenewListener {
+
+    override suspend fun preferredEndDate(maximumDate: Date?): Date? = suspendCancellableCoroutine { cont ->
+        val start = license.license.rights.end?.millis ?: Date().time
+        val end = maximumDate?.time
+
+        MaterialDatePicker.Builder.datePicker()
+            .setCalendarConstraints(CalendarConstraints.Builder().apply {
+                // Restricts the choice between the license expiration date and the given
+                // maximumDate.
+                setStart(start)
+                if (end != null) {
+                    setEnd(end)
+                }
+                setValidator(CompositeDateValidator.allOf(listOfNotNull(
+                    DateValidatorPointForward.from(start),
+                    end?.let { DateValidatorPointBackward.before(end) }
+                )))
+            }.build())
+            .setSelection(start)
+            .build()
+            .apply {
+                addOnCancelListener { cont.cancel() }
+                addOnNegativeButtonClickListener { cont.cancel() }
+
+                addOnPositiveButtonClickListener { selection ->
+                    cont.resume(Date(selection))
+                }
+            }
+            .show(fragmentManager, "MaterialRenewListener.DatePicker")
+    }
+
+    override suspend fun openWebPage(url: URL) = suspendCoroutine<Unit> { cont ->
+        webPageContinuation = cont
+
+        webPageLauncher.launch(
+            CustomTabsIntent.Builder().build().intent.apply {
+                data = Uri.parse(url.toString())
+            }
+        )
+    }
+
+    private var webPageContinuation: Continuation<Unit>? = null
+
+    private val webPageLauncher = caller.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        webPageContinuation?.resume(Unit)
+    }
+
+}
+

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/License.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/License.kt
@@ -9,6 +9,7 @@
 
 package org.readium.r2.lcp.license
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.joda.time.DateTime
@@ -17,16 +18,19 @@ import org.readium.r2.lcp.LcpException
 import org.readium.r2.lcp.LcpLicense
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.StatusDocument
+import org.readium.r2.lcp.license.model.components.Link
 import org.readium.r2.lcp.service.DeviceService
 import org.readium.r2.lcp.service.LcpClient
 import org.readium.r2.lcp.service.LicensesRepository
 import org.readium.r2.lcp.service.NetworkService
+import org.readium.r2.shared.extensions.tryOrNull
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.getOrElse
 import org.readium.r2.shared.util.mediatype.MediaType
 import timber.log.Timber
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.*
 
 internal class License(
     private var documents: ValidatedDocuments,
@@ -132,10 +136,43 @@ internal class License(
     override val maxRenewDate: DateTime?
         get() = status?.potentialRights?.end
 
-    override suspend fun renewLoan(end: DateTime?, urlPresenter: suspend (URL) -> Unit): Try<Unit, LcpException> {
+    override suspend fun renewLoan(listener: LcpLicense.RenewListener, prefersWebPage: Boolean): Try<Date?, LcpException> {
 
-        suspend fun callPUT(url: URL): ByteArray =
-            network.fetch(url.toString(), NetworkService.Method.PUT)
+        // Finds the renew link according to `prefersWebPage`.
+        fun findRenewLink(): Link? {
+            val status = documents.status ?: return null
+
+            val types = mutableListOf(MediaType.HTML, MediaType.XHTML)
+            if (prefersWebPage) {
+                types.add(MediaType.LCP_STATUS_DOCUMENT)
+            } else {
+                types.add(0, MediaType.LCP_STATUS_DOCUMENT)
+            }
+
+            for (type in types) {
+                return status.link(StatusDocument.Rel.renew, type = type)
+                    ?: continue
+            }
+
+            // Fallback on the first renew link with no media type set and assume it's a PUT action.
+            return status.linkWithNoType(StatusDocument.Rel.renew)
+        }
+
+        // Programmatically renew the loan with a PUT request.
+        suspend fun renewProgrammatically(link: Link): ByteArray {
+            val endDate =
+                if (link.templateParameters.contains("end"))
+                    listener.preferredEndDate(maxRenewDate?.toDate())
+                else null
+
+            val parameters = this.device.asQueryParameters.toMutableMap()
+            if (endDate != null) {
+                parameters["end"] = DateTime(endDate).toString()
+            }
+
+            val url = link.url(parameters)
+
+            return network.fetch(url.toString(), NetworkService.Method.PUT)
                 .getOrElse { error ->
                     when (error.status) {
                         HttpURLConnection.HTTP_BAD_REQUEST -> throw LcpException.Renew.RenewFailed
@@ -143,39 +180,38 @@ internal class License(
                         else -> throw LcpException.Renew.UnexpectedServerError
                     }
                 }
+        }
 
-        // TODO needs to be tested
-        suspend fun callHTML(url: URL): ByteArray {
-            val statusURL = try {
-                this.license.url(LicenseDocument.Rel.status, preferredType = MediaType.LCP_LICENSE_DOCUMENT)
-            } catch (e: Throwable) {
-                null
+        // Renew the loan by presenting a web page to the user.
+        suspend fun renewWithWebPage(link: Link): ByteArray {
+            // The reading app will open the URL in a web view and return when it is dismissed.
+            listener.openWebPage(link.url)
+
+            val statusURL = tryOrNull {
+                license.url(LicenseDocument.Rel.status, preferredType = MediaType.LCP_STATUS_DOCUMENT)
             } ?: throw LcpException.LicenseInteractionNotAvailable
-            urlPresenter(url)
 
-            return network.fetch(statusURL.toString())
-                .getOrElse { throw LcpException.Network(it) }
+            return network.fetch(statusURL.toString()).getOrThrow()
         }
 
         try {
-            val parameters = this.device.asQueryParameters.toMutableMap()
-            end?.let {
-                parameters["end"] = end.toString()
-            }
-            val status = this.documents.status
-            val link = status?.link(StatusDocument.Rel.renew)
-            val url = link?.url(parameters)
-            if (status == null || link == null || url == null) {
-                throw LcpException.LicenseInteractionNotAvailable
-            }
-            val data = if (link.mediaType.isHtml) {
-                callHTML(url)
-            } else {
-                callPUT(url)
-            }
+            val link = findRenewLink()
+                ?: throw LcpException.LicenseInteractionNotAvailable
+
+            val data =
+                if (link.mediaType.isHtml) {
+                    renewWithWebPage(link)
+                } else {
+                    renewProgrammatically(link)
+                }
+
             validateStatusDocument(data)
 
-            return Try.success(Unit)
+            return Try.success(documents.license.rights.end?.toDate())
+
+        } catch (e: CancellationException) {
+            // Passthrough for cancelled coroutines
+            throw e
 
         } catch (e: Exception) {
             return Try.failure(LcpException.wrap(e))

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/LicenseValidation.kt
@@ -10,21 +10,17 @@
 package org.readium.r2.lcp.license
 
 import kotlinx.coroutines.runBlocking
-import org.joda.time.DateTime
 import org.readium.r2.lcp.BuildConfig.DEBUG
 import org.readium.r2.lcp.LcpAuthenticating
 import org.readium.r2.lcp.LcpException
 import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.license.model.StatusDocument
 import org.readium.r2.lcp.license.model.components.Link
-import org.readium.r2.lcp.service.CRLService
-import org.readium.r2.lcp.service.DeviceService
-import org.readium.r2.lcp.service.LcpClient
-import org.readium.r2.lcp.service.NetworkService
-import org.readium.r2.lcp.service.PassphrasesService
+import org.readium.r2.lcp.service.*
 import org.readium.r2.shared.util.getOrElse
 import org.readium.r2.shared.util.mediatype.MediaType
 import timber.log.Timber
+import java.util.*
 import kotlin.time.ExperimentalTime
 import kotlin.time.seconds
 
@@ -341,7 +337,7 @@ internal class LicenseValidation(
 
     private fun checkLicenseStatus(license: LicenseDocument, status: StatusDocument?) {
         var error: LcpException.LicenseStatus? = null
-        val now = DateTime()
+        val now = Date()
         val start = license.rights.start ?: now
         val end = license.rights.end ?: now
         if (start > now || now > end) {
@@ -349,7 +345,7 @@ internal class LicenseValidation(
                 val date = status.statusUpdated
                 when (status.status) {
                     StatusDocument.Status.ready, StatusDocument.Status.active, StatusDocument.Status.expired ->
-                        if (start > DateTime()) {
+                        if (start > now) {
                             LcpException.LicenseStatus.NotStarted(start)
                         } else {
                             LcpException.LicenseStatus.Expired(end)
@@ -362,7 +358,7 @@ internal class LicenseValidation(
                     StatusDocument.Status.cancelled -> LcpException.LicenseStatus.Cancelled(date)
                 }
             } else {
-                if (start > DateTime()) {
+                if (start > now) {
                     LcpException.LicenseStatus.NotStarted(start)
                 } else {
                     LcpException.LicenseStatus.Expired(end)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/StatusDocument.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/StatusDocument.kt
@@ -94,9 +94,12 @@ class StatusDocument(val data: ByteArray) {
     fun links(rel: Rel, type: MediaType? = null): List<Link> =
         links.allWithRel(rel.rawValue, type)
 
+    internal fun linkWithNoType(rel: Rel): Link? =
+        links.firstWithRelAndNoType(rel.rawValue)
+
     fun url(rel: Rel, preferredType: MediaType? = null, parameters:  URLParameters = emptyMap()): URL {
         val link = link(rel, preferredType)
-            ?: links.firstWithRelAndNoType(rel.rawValue)
+            ?: linkWithNoType(rel)
             ?: throw LcpException.Parsing.Url(rel = rel.rawValue)
 
         return link.url(parameters)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/Link.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/Link.kt
@@ -14,6 +14,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.readium.r2.lcp.LcpException
 import org.readium.r2.lcp.service.URLParameters
+import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.util.URITemplate
 import java.net.URL
@@ -70,5 +71,15 @@ data class Link(val json: JSONObject) {
 
     val mediaType: MediaType
         get() = type?.let { MediaType.parse(it) } ?: MediaType.BINARY
+
+    /**
+     * List of URI template parameter keys, if the [Link] is templated.
+     */
+    internal val templateParameters: List<String> by lazy {
+        if (!templated)
+            emptyList()
+        else
+            URITemplate(href).parameters
+    }
 
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lcp/Rights.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lcp/Rights.kt
@@ -1,4 +1,3 @@
-// TODO: extensions
 /*
  * Module: r2-lcp-kotlin
  * Developers: Aferdita Muriqi
@@ -10,27 +9,27 @@
 
 package org.readium.r2.lcp.license.model.components.lcp
 
-import org.joda.time.DateTime
 import org.json.JSONObject
+import org.readium.r2.shared.extensions.iso8601ToDate
+import org.readium.r2.shared.extensions.optNullableInt
+import org.readium.r2.shared.extensions.optNullableString
+import java.util.*
 
 data class Rights(val json: JSONObject) {
     val print: Int?
     val copy: Int?
-    val start: DateTime?
-    val end: DateTime?
+    val start: Date?
+    val end: Date?
     val extensions: JSONObject
 
     init {
-        print = if (json.has("print")) json.getInt("print") else null
-        copy = if (json.has("copy")) json.getInt("copy") else null
-        start = if (json.has("start")) DateTime(json.getString("start")) else null
-        end = if (json.has("end")) DateTime(json.getString("end")) else null
+        val clone = JSONObject(json.toString())
 
-//        json.remove("print")
-//        json.remove("copy")
-//        json.remove("start")
-//        json.remove("end")
+        print = clone.optNullableInt("print", remove = true)
+        copy = clone.optNullableInt("copy", remove = true)
+        start = clone.optNullableString("start", remove = true)?.iso8601ToDate()
+        end = clone.optNullableString("end", remove = true)?.iso8601ToDate()
 
-        extensions = json
+        extensions = clone
     }
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lcp/Signature.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lcp/Signature.kt
@@ -11,15 +11,10 @@ package org.readium.r2.lcp.license.model.components.lcp
 
 import org.json.JSONObject
 import org.readium.r2.lcp.LcpException
+import org.readium.r2.shared.extensions.optNullableString
 
 data class Signature(val json: JSONObject) {
-    val algorithm: String
-    val certificate: String
-    val value: String
-
-    init {
-        algorithm = if (json.has("algorithm")) json.getString("algorithm") else throw LcpException.Parsing.Signature
-        certificate = if (json.has("certificate")) json.getString("certificate") else throw LcpException.Parsing.Signature
-        value = if (json.has("value")) json.getString("value") else throw LcpException.Parsing.Signature
-    }
+    val algorithm: String = json.optNullableString("algorithm") ?: throw LcpException.Parsing.Signature
+    val certificate: String = json.optNullableString("certificate") ?: throw LcpException.Parsing.Signature
+    val value: String = json.optNullableString("value") ?: throw LcpException.Parsing.Signature
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lsd/Event.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lsd/Event.kt
@@ -9,14 +9,16 @@
 
 package org.readium.r2.lcp.license.model.components.lsd
 
-import org.joda.time.DateTime
 import org.json.JSONObject
+import org.readium.r2.shared.extensions.iso8601ToDate
+import org.readium.r2.shared.extensions.optNullableString
+import java.util.*
 
 data class Event(val json: JSONObject) {
-    val type: String
-    val name: String
-    val id: String
-    val date: DateTime
+    val type: String = json.optNullableString("type") ?: ""
+    val name: String = json.optNullableString("name") ?: ""
+    val id: String = json.optNullableString("id") ?: ""
+    val date: Date? = json.optNullableString("timestamp")?.iso8601ToDate()
 
     enum class EventType(val rawValue: String) {
         register("register"),
@@ -30,11 +32,4 @@ data class Event(val json: JSONObject) {
         }
     }
 
-    init {
-        type = try {json.getString("type")}finally { }
-        name = try {json.getString("name")}finally { }
-        id = try {json.getString("id") }finally { }
-        date = try {DateTime(json.getString("timestamp")) }finally { }
-
-    }
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lsd/PotentialRights.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/model/components/lsd/PotentialRights.kt
@@ -9,13 +9,11 @@
 
 package org.readium.r2.lcp.license.model.components.lsd
 
-import org.joda.time.DateTime
 import org.json.JSONObject
+import org.readium.r2.shared.extensions.iso8601ToDate
+import org.readium.r2.shared.extensions.optNullableString
+import java.util.*
 
 data class PotentialRights(val json: JSONObject) {
-    val end: DateTime?
-
-    init {
-        end = if (json.has("end")) DateTime(json.getString("end")) else null
-    }
+    val end: Date? = json.optNullableString("end")?.iso8601ToDate()
 }

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/service/CRLService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/service/CRLService.kt
@@ -12,12 +12,10 @@ package org.readium.r2.lcp.service
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
-import kotlinx.coroutines.runBlocking
 import org.joda.time.DateTime
 import org.joda.time.Days
 import org.readium.r2.lcp.BuildConfig.DEBUG
 import org.readium.r2.lcp.LcpException
-import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.getOrElse
 import timber.log.Timber
 import java.util.*
@@ -63,9 +61,7 @@ internal class CRLService(val network: NetworkService, val context: Context) {
     // Returns (CRL, expired)
     private fun readLocal(): Pair<String?, Boolean> {
         val crl = preferences.getString(crlKey, null)
-        val date = preferences.getString(dateKey, null)?.let {
-            DateTime(preferences.getString(dateKey, null))
-        }
+        val date = preferences.getString(dateKey, null)?.let { DateTime(it) }
         val expired = date?.let { daysSince(date) >= expiration } ?: true
         return Pair(crl, expired)
     }


### PR DESCRIPTION
* Extensibility in licenses' `Rights` model.
* The Renew Loan API got revamped to better support renewal through a web page.
    * You will need to implement `LcpLicense.RenewListener` to coordinate the UX interaction.
    * If your application fits Material Design guidelines, take a look at `MaterialRenewListener` for a default implementation.
* Removed dependency on Joda's `DateTime` in public APIs.
    * You can always create a `DateTime` from the standard `Date` objects if you relied on Joda's features in the callers.

See https://github.com/readium/lcp-specs/issues/43 for discussion.