### PR TITLE
Add a way to observe an acquisition's progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* You can observe the progress of an acquisition by providing an `onProgress` closure to `LcpService.acquirePublication()`.
+
+
 ## [2.0.0-beta.1]
 
-## Changed
+### Changed
 
 * Upgraded to Kotlin 1.4.10.
 
-## Fixed
+### Fixed
 
 * When acquiring a publication, falls back on the media type declared in the license link if the server returns an unknown media type.
 

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpService.kt
@@ -34,15 +34,23 @@ interface LcpService {
 
     /**
      * Acquires a protected publication from a standalone LCPL's bytes.
+     *
+     * You can cancel the on-going acquisition by cancelling its parent coroutine context.
+     *
+     * @param onProgress Callback to follow the acquisition progress from 0.0 to 1.0.
      */
-    suspend fun acquirePublication(lcpl: ByteArray): Try<AcquiredPublication, LcpException>
+    suspend fun acquirePublication(lcpl: ByteArray, onProgress: (Double) -> Unit = {}): Try<AcquiredPublication, LcpException>
 
     /**
-     *  Acquires a protected publication from a standalone LCPL file.
+     * Acquires a protected publication from a standalone LCPL file.
+     *
+     * You can cancel the on-going acquisition by cancelling its parent coroutine context.
+     *
+     * @param onProgress Callback to follow the acquisition progress from 0.0 to 1.0.
      */
-    suspend fun acquirePublication(lcpl: File): Try<AcquiredPublication, LcpException> = withContext(Dispatchers.IO) {
+    suspend fun acquirePublication(lcpl: File, onProgress: (Double) -> Unit = {}): Try<AcquiredPublication, LcpException> = withContext(Dispatchers.IO) {
         try {
-            acquirePublication(lcpl.readBytes())
+            acquirePublication(lcpl.readBytes(), onProgress)
         } catch (e: Exception) {
             Try.failure(LcpException.wrap(e))
         }


### PR DESCRIPTION
Fix #72 

* You can observe the progress of an acquisition by providing an `onProgress` closure to `LcpService.acquirePublication()`.
