### PR TITLE
Fix passphrase input not entirely visible on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+* [#287](https://github.com/readium/r2-testapp-kotlin/issues/287) Make sure the passphrase input is visible on smaller devices in the authentication dialog.
+
 ## [2.0.0-beta.1]
 
 ## Changed

--- a/r2-lcp/src/main/res/layout/r2_lcp_auth_dialog.xml
+++ b/r2-lcp/src/main/res/layout/r2_lcp_auth_dialog.xml
@@ -62,7 +62,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/r2_passwordLayout"
-            android:layout_width="395dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"


### PR DESCRIPTION
Fix https://github.com/readium/r2-testapp-kotlin/issues/287