### PR TITLE
Fix copy and print restrictions and information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+* [#267](https://github.com/readium/r2-testapp-kotlin/issues/267) Prints and copy characters left are now properly reported (contributed by [@qnga](https://github.com/readium/r2-lcp-kotlin/pull/104)).
+
 
 ## [2.0.0-beta.2]
 

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/license/License.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/license/License.kt
@@ -115,13 +115,13 @@ internal class License(
         pagesToPrintLeft?.let { it <= pageCount }
             ?: true
 
-    override fun print(pagesCount: Int): Boolean {
+    override fun print(pageCount: Int): Boolean {
         var pagesLeft = pagesToPrintLeft ?: return true
-        if (pagesLeft < pagesCount) {
+        if (pagesLeft < pageCount) {
             return false
         }
         try {
-            pagesLeft = maxOf(0, pagesLeft - pagesCount)
+            pagesLeft = maxOf(0, pagesLeft - pageCount)
             licenses.setPrintsLeft(pagesLeft, license.id)
         } catch (error: Error) {
             if (DEBUG) Timber.e(error)

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/persistence/Licenses.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/persistence/Licenses.kt
@@ -14,6 +14,7 @@ import org.readium.r2.lcp.license.model.LicenseDocument
 import org.readium.r2.lcp.LcpException
 import org.readium.r2.lcp.service.DeviceRepository
 import org.readium.r2.lcp.service.LicensesRepository
+import timber.log.Timber
 
 internal object LicensesTable {
     const val NAME = "Licenses"
@@ -49,12 +50,9 @@ internal class Licenses(var database: LcpDatabaseOpenHelper) : DeviceRepository,
                             return@rowParser result
                         }
                         try {
-                            if (parseList(parser).isNullOrEmpty()) {
-                                null
-                            } else {
-                                parseList(parser)[0]
-                            }
+                            parseList(parser).firstOrNull()
                         } catch (e: Exception) {
+                            Timber.d(e)
                             null
                         }
                     }


### PR DESCRIPTION
Because `license.charactersToCopyLeft` and `license.pagesToPrintLeft` were always null, right informations were wrong, and copy and print were unrestricted.

Fix https://github.com/readium/r2-testapp-kotlin/issues/267