### PR TITLE
Warnings cleanup and dependency updates

### DIFF
--- a/r2-lcp/build.gradle
+++ b/r2-lcp/build.gradle
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
 
     if (findProject(':r2-shared')) {
         implementation project(':r2-shared')

--- a/r2-lcp/build.gradle
+++ b/r2-lcp/build.gradle
@@ -27,6 +27,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
     buildTypes {
         release {
@@ -48,7 +49,7 @@ dependencies {
 
 
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
-    implementation "androidx.core:core-ktx:1.3.2"
+    implementation "androidx.core:core-ktx:1.5.0"
     implementation "com.google.android.material:material:1.3.0"
     implementation "com.jakewharton.timber:timber:4.7.1"
     implementation("com.mcxiaoke.koi:async:0.5.5") {
@@ -57,7 +58,7 @@ dependencies {
     implementation("com.mcxiaoke.koi:core:0.5.5") {
         exclude module: 'support-v4'
     }
-    implementation "joda-time:joda-time:2.10.5"
+    implementation "joda-time:joda-time:2.10.10"
     implementation "org.jetbrains.anko:anko-sqlite:0.10.8"
     implementation "org.zeroturnaround:zt-zip:1.14"
     implementation 'androidx.browser:browser:1.3.0'

--- a/r2-lcp/build.gradle
+++ b/r2-lcp/build.gradle
@@ -28,6 +28,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
         freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        allWarningsAsErrors = true
     }
     buildTypes {
         release {


### PR DESCRIPTION
Cleaned up warnings by adding `freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"` to kotlinOptions.

Dependencies were also updated.