### PR TITLE
Fix a bug in LcpContentProtection

### DIFF
--- a/r2-lcp/src/main/AndroidManifest.xml
+++ b/r2-lcp/src/main/AndroidManifest.xml
@@ -12,5 +12,6 @@
 
     <!-- Used to get the device's name for LSD "register" -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
 </manifest>

--- a/r2-lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
+++ b/r2-lcp/src/main/java/org/readium/r2/lcp/LcpContentProtection.kt
@@ -15,7 +15,6 @@ import org.readium.r2.shared.publication.asset.FileAsset
 import org.readium.r2.shared.publication.asset.PublicationAsset
 import org.readium.r2.shared.publication.services.contentProtectionServiceFactory
 import org.readium.r2.shared.util.Try
-import timber.log.Timber
 
 internal class LcpContentProtection(
     private val lcpService: LcpService,
@@ -30,7 +29,7 @@ internal class LcpContentProtection(
         sender: Any?
     ): Try<ContentProtection.ProtectedAsset, Publication.OpeningException>? {
         if (asset !is FileAsset) {
-            return Try.failure(Publication.OpeningException.UnsupportedFormat(Exception("Only `FileAsset` is supported with the `LcpContentProtection`, make sure you are trying to open a package from the file system")))
+            return null
         }
 
         if (!lcpService.isLcpProtected(asset.file)) {


### PR DESCRIPTION
LcpContentProtection.open should not assume the asset is appropriate for it and return null if not.
Otherwise, it doesn't let any chance to other ContentProtections to open the asset.